### PR TITLE
Setup Travis-CI and pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,55 @@
+# MMMMMMMMMMMMOMOOOQQQQQQQQQQQQQQ$$$$QQQQQQQQQQ$$OO$OOMMMMMMMMMMMMMMMMMM
+# MMMMMMMMMMMMOOOO$Q$QQQQQQQQQQQQQQQQQQQQQQQQQQQQ$OOMOMMMMMMMMMMMMMMMMMM
+# MMMMMMMMMMMOOMMOO$QQQQQQQQQQQQQQQ$QQQQQQQQQQQQ$QOO$MOMMMMMMMMMMMMMMMMM
+# MMMMMMMMMOOMMOOOO$Q$QQQQQQQQQQQQQQ$$$Q$$$$$$$$$QOO$MOMMMMMMMMMMMMMMMMM
+# MMMMMMMMMMMOOOO$$QQQQQQQQQQQQQQ$$$QQQQ$$$$$$$$Q$OOMHMMMMMMMMMMMMMMMMMM
+# MMMMMMMOOOOO$$QQQQQQQQQQQQQQQ$QQQ$$$$$OCCCCCCOOOQMNMMMMMMMMMMMMMMMMMMM
+# MMMMMMMOMOO$QQ$$QQQQQQQQQQQ$QQ$$$O?7>!!!::::::!>$NMMMHMMMMMMMMMMMMMMMM
+# MMMMMMOM$O$Q$QQQQQQQQQQQQQ$Q$$OC>!::::---:::!!::::7$NMMNMMMMMMMMMMMMMM
+# MMMMMMNM OOQ$QQQQQQQQQQQQ$Q$OC>::-;.        .;:!!::-!CNMMNMMMMMMMMMMMM
+# MMMMMMM$MHO$Q$$$$$$QQQQQ$Q$OC!-;               .;:!!:::CNMMMMMMMMMMMMM
+# MMMMMMMMM7>O$Q$$$$$$Q$Q$Q$O?-.                    ;:!!::!$MMMMMMMMMMMM
+# MMMMMMMH-  :?O$$$$$$$QQQ$O?.                        ;:!:::?MMMMMMMMMMM
+# MMMMMMQ.     ;-:::;7O$Q$O7.                           -!:!-7MMMMMMMMMM
+# MMMMMH;......      .?$$$O!............................ -!:!:7MMMMMMMMM
+# MMMMMMNMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMNM> -!:!-?MMMMMMMM
+# $HMMMMMMMMMMMMMMMMMM7::>!OMMQ$HMMH$QMMMMMMMMMMMMMMMMMM?  :::!:QMMMMMMM
+# QHHHMMMMMMMMMMMMMMMM-    7MMHQQHHHQQHHNMMMMMMMMMMMMNCC:  ;!:::7MMMMMMM
+# MN$$HMMMMMMMMMMMMMHN-    7HHMMN$$NMM$OQMMMMMMMMMMNHO     .!::::HMMMMMM
+# O$MMQOOMMMMMMMMMMC          NMMMMQO$MMHOONMMMMMMM-       ;!::!:$MMMMMM
+# NMMMMMMMMMMMMMM:-.          --7MMMMMMMMMMMMMMMO-:        ::::!:CMMMMMM
+# MMMO?????????77.->?CCOOCC?>:. .???????????????:         -!:::!:CMMMMMM
+# MMM!         -?$$OC??????CO$$C-                       .:!::::!:CMMMMMM
+# MMM?       -$QC?777777777777?CQC                      :!:::::!:CMMMMMM
+# MMM$      :HO777?????????????7?Q7                     :::::::::?MMMMMM
+# MMMH     .QO7?????????????????7QO                     .!:::::::>MMMMMM
+# MMMM     !H???77777????????777OH$?;                    ;!:::::::QMMMMM
+# MMMN-    :H$OO$OOC?77777777?C$QQ$$C.                    ::::::::7MMMMM
+# MMM$::    C; .;-?QQ$$OOOO$$QQQ$$Q$O!                   .::::::::-HMMMM
+# MMMO-::;        ?$QQQQQQQQQQ$$QQ$Q$?                   :!::::::>QMMMMM
+# MMMN?>!>!-;.   :O$Q$$$$$$$$QQQQQ$Q$C                 .:!::::!:OMMMMMMM
+# MMMMMMMM$:!!::-7O$Q$QQQQ$QQQQQQQ$$$?                ;:!::::::-$MMMMMMM
+# MMMMMMMMH:-::!!>O$QQ$QQ$$$Q$QQQ$Q$O!             .-:!:::::!>7ONMMMMMMM
+# MMMMMMMMMHC7!::-!CO$$$$OCO$QQQQQ$$C           .-:!!::!:>$NNMMMMMMMMMMM
+# MMMMMMMMMMMMMHQO>:!>>>>!:?O$$QQ$$?;    ..;;-::!!::::::>MMMMM MMMMMMMMM
+# MMMMMMMMMMMMMMMMMQ>:::::::>?O$OC7:-:::::!!!!:::::!>>7ONMMMMMMMMMMMMMMM
+
+
+- repo: git://github.com/pre-commit/pre-commit-hooks
+  sha: v0.4.2
+  hooks:
+    - id: trailing-whitespace
+    - id: end-of-file-fixer
+
+- repo: local
+  hooks:
+  - id: make
+    name: make
+    entry: cd src && bash -ec 'make'
+    language: system
+    files: \.cpp$
+  - id: lint
+    name: lint
+    entry: cpplint
+    language: system
+    files: \.cpp$

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,55 @@
+# MMMMMMMMMMMMOMOOOQQQQQQQQQQQQQQ$$$$QQQQQQQQQQ$$OO$OOMMMMMMMMMMMMMMMMMM
+# MMMMMMMMMMMMOOOO$Q$QQQQQQQQQQQQQQQQQQQQQQQQQQQQ$OOMOMMMMMMMMMMMMMMMMMM
+# MMMMMMMMMMMOOMMOO$QQQQQQQQQQQQQQQ$QQQQQQQQQQQQ$QOO$MOMMMMMMMMMMMMMMMMM
+# MMMMMMMMMOOMMOOOO$Q$QQQQQQQQQQQQQQ$$$Q$$$$$$$$$QOO$MOMMMMMMMMMMMMMMMMM
+# MMMMMMMMMMMOOOO$$QQQQQQQQQQQQQQ$$$QQQQ$$$$$$$$Q$OOMHMMMMMMMMMMMMMMMMMM
+# MMMMMMMOOOOO$$QQQQQQQQQQQQQQQ$QQQ$$$$$OCCCCCCOOOQMNMMMMMMMMMMMMMMMMMMM
+# MMMMMMMOMOO$QQ$$QQQQQQQQQQQ$QQ$$$O?7>!!!::::::!>$NMMMHMMMMMMMMMMMMMMMM
+# MMMMMMOM$O$Q$QQQQQQQQQQQQQ$Q$$OC>!::::---:::!!::::7$NMMNMMMMMMMMMMMMMM
+# MMMMMMNM OOQ$QQQQQQQQQQQQ$Q$OC>::-;.        .;:!!::-!CNMMNMMMMMMMMMMMM
+# MMMMMMM$MHO$Q$$$$$$QQQQQ$Q$OC!-;               .;:!!:::CNMMMMMMMMMMMMM
+# MMMMMMMMM7>O$Q$$$$$$Q$Q$Q$O?-.                    ;:!!::!$MMMMMMMMMMMM
+# MMMMMMMH-  :?O$$$$$$$QQQ$O?.                        ;:!:::?MMMMMMMMMMM
+# MMMMMMQ.     ;-:::;7O$Q$O7.                           -!:!-7MMMMMMMMMM
+# MMMMMH;......      .?$$$O!............................ -!:!:7MMMMMMMMM
+# MMMMMMNMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMNM> -!:!-?MMMMMMMM
+# $HMMMMMMMMMMMMMMMMMM7::>!OMMQ$HMMH$QMMMMMMMMMMMMMMMMMM?  :::!:QMMMMMMM
+# QHHHMMMMMMMMMMMMMMMM-    7MMHQQHHHQQHHNMMMMMMMMMMMMNCC:  ;!:::7MMMMMMM
+# MN$$HMMMMMMMMMMMMMHN-    7HHMMN$$NMM$OQMMMMMMMMMMNHO     .!::::HMMMMMM
+# O$MMQOOMMMMMMMMMMC          NMMMMQO$MMHOONMMMMMMM-       ;!::!:$MMMMMM
+# NMMMMMMMMMMMMMM:-.          --7MMMMMMMMMMMMMMMO-:        ::::!:CMMMMMM
+# MMMO?????????77.->?CCOOCC?>:. .???????????????:         -!:::!:CMMMMMM
+# MMM!         -?$$OC??????CO$$C-                       .:!::::!:CMMMMMM
+# MMM?       -$QC?777777777777?CQC                      :!:::::!:CMMMMMM
+# MMM$      :HO777?????????????7?Q7                     :::::::::?MMMMMM
+# MMMH     .QO7?????????????????7QO                     .!:::::::>MMMMMM
+# MMMM     !H???77777????????777OH$?;                    ;!:::::::QMMMMM
+# MMMN-    :H$OO$OOC?77777777?C$QQ$$C.                    ::::::::7MMMMM
+# MMM$::    C; .;-?QQ$$OOOO$$QQQ$$Q$O!                   .::::::::-HMMMM
+# MMMO-::;        ?$QQQQQQQQQQ$$QQ$Q$?                   :!::::::>QMMMMM
+# MMMN?>!>!-;.   :O$Q$$$$$$$$QQQQQ$Q$C                 .:!::::!:OMMMMMMM
+# MMMMMMMM$:!!::-7O$Q$QQQQ$QQQQQQQ$$$?                ;:!::::::-$MMMMMMM
+# MMMMMMMMH:-::!!>O$QQ$QQ$$$Q$QQQ$Q$O!             .-:!:::::!>7ONMMMMMMM
+# MMMMMMMMMHC7!::-!CO$$$$OCO$QQQQQ$$C           .-:!!::!:>$NNMMMMMMMMMMM
+# MMMMMMMMMMMMMHQO>:!>>>>!:?O$$QQ$$?;    ..;;-::!!::::::>MMMMM MMMMMMMMM
+# MMMMMMMMMMMMMMMMMQ>:::::::>?O$OC7:-:::::!!!!:::::!>>7ONMMMMMMMMMMMMMMM
+
+
+
+language: cpp
+
+compiler:
+  - clang
+  - gcc
+
+sudo: true
+
+install: sudo apt-get install gcc clang-3.7 clang-3.7-doc \
+                                  libclang-common-3.7-dev libclang-3.7-dev \
+                                  libclang1-3.7 libclang1-3.7-dbg libllvm-3.7-ocaml-dev \
+                                  libllvm3.7 libllvm3.7-dbg lldb-3.7 llvm-3.7 llvm-3.7-dev \
+                                  llvm-3.7-doc llvm-3.7-examples llvm-3.7-runtime clang-modernize-3.7 \
+                                  clang-format-3.7 python-clang-3.7 lldb-3.7-dev \
+
+script: cd src && make
+  

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # Brain
+[![Build Status](https://travis-ci.org/luizperes/brain.svg?branch=master)](https://travis-ci.org/luizperes/brain)
+
 A computer language based on Brainfuck.
 
 ### Information


### PR DESCRIPTION
Travis
------
I have some troubles compiling the project, probably
dependency hell with llvm libs. You probably need
check later the install key on the .travis.yml
about installing the correct dependecies, like
clang and llvm libs. Oh, besides, you can setup
in theory the compilers on file, but I don know
how this works because you already explicilty defines
the usage of clang on makefile.

Pre-commit
---------
You can setup the pre-commit in you machine that wa
Mac OS
------
```
brew install pre-commit
```

Linux
-----
```
sudo pip install pre-commit
```

After this, you just call `pre-commit install` in the root
of your project to linkate the python hooks with your
.git/hooks/pre-commit.

This is the default behavior. I tested here and works fine.

The pre-commit hooks I setup are:

* trailing-whitespaces
* end-of-file-fixer
* cpplint

You can look for more public hooks here:
[pre-commit-catalog](http://pre-commit.com/hooks.html)

Extra
-----
BTW, I add the awesome chicken ascii art in all yml files
because I just love your picture profile.