### PR TITLE
Refactor following the Stroustrup guidelines

### DIFF
--- a/src/ast/expr/ArithmeticExpr.cpp
+++ b/src/ast/expr/ArithmeticExpr.cpp
@@ -1,3 +1,4 @@
+
 /* This is the source code of Brain Programming Language.
  * It is licensed under GNU GPL v. 3 or later.
  * You should have received a copy of the license in this archive (see LICENSE).
@@ -7,81 +8,68 @@
 
 #include "ArithmeticExpr.h"
 
-void ArithmeticExpr::CodeGen(llvm::Module *M, llvm::IRBuilder<> &B, llvm::GlobalVariable *index, llvm::GlobalVariable *cells)
+void ArithmeticExpression::code_gen(llvm::Module *M, llvm::IRBuilder<> &B, llvm::GlobalVariable *index, llvm::GlobalVariable *cells)
 {
-  llvm::Value *IdxV = B.CreateLoad(index);  
-  llvm::Value* Idxs[] = { B.getInt32(0), IdxV };
-  llvm::ArrayRef<llvm::Value *> IdxsArr(Idxs);
-  llvm::Value *CellPtr = B.CreateGEP(cells, IdxsArr);
-  // Load cell value
-  llvm::Value *CellV = B.CreateLoad(CellPtr);
+    llvm::Value *IdxV = B.CreateLoad(index);  
+    llvm::Value* Idxs[] = { B.getInt32(0), IdxV };
+    llvm::ArrayRef<llvm::Value *> IdxsArr(Idxs);
+    llvm::Value *CellPtr = B.CreateGEP(cells, IdxsArr);
+    // Load cell value
+    llvm::Value *CellV = B.CreateLoad(CellPtr);
+    
+    // Load index value - 1
+    llvm::Value *IdxPreV = B.CreateAdd(IdxV, B.getInt32(-1));
+    llvm::Value* Idxs2[] = { B.getInt32(0), IdxPreV };
+    llvm::ArrayRef<llvm::Value *> IdxsArr2(Idxs2);
+    llvm::Value *CellPtr2 = B.CreateGEP(cells, IdxsArr2);
+    // Load cell value
+    llvm::Value *CellV2 = B.CreateLoad(CellPtr2);
 
-   // Load index value - 1
-  llvm::Value *IdxPreV = B.CreateAdd(IdxV, B.getInt32(-1));
-  llvm::Value* Idxs2[] = { B.getInt32(0), IdxPreV };
-  llvm::ArrayRef<llvm::Value *> IdxsArr2(Idxs2);
-  llvm::Value *CellPtr2 = B.CreateGEP(cells, IdxsArr2);
-  // Load cell value
-  llvm::Value *CellV2 = B.CreateLoad(CellPtr2);
-
-  switch (_type)
-  {
-    case AT_MUL:
+    switch (_type)
     {
-      // Multiplies the value at the current index with the value at the current index - 1 and
-      // stores it at the current index
-      B.CreateStore(B.CreateMul(CellV, CellV2), CellPtr);
-      break;
-    }
+    case AT_MUL:	
+	// Multiplies the value at the current index with the value
+	// at index - 1 and stores it at the current index.
+	B.CreateStore(B.CreateMul(CellV, CellV2), CellPtr);
+	break;
     case AT_DIV:
-    {
-      B.CreateStore(B.CreateSDiv(CellV, CellV2), CellPtr);
-      break;
-    }
+	B.CreateStore(B.CreateSDiv(CellV, CellV2), CellPtr);
+	break;
     case AT_REM:
-    {
-      B.CreateStore(B.CreateSRem(CellV, CellV2), CellPtr);
-      break;
+	B.CreateStore(B.CreateSRem(CellV, CellV2), CellPtr);
+	break;
     }
-  }
 }
 
-void ArithmeticExpr::DebugDescription(int level)
+void ArithmeticExpression::debug_description(int level)
 {
-  std::cout.width(level);
-  if (ArgsOptions::instance()->hasOption(BO_IS_VERBOSE))
-  {
-    std::cout << "Arithmetic Expression - " << TypeToString() 
-              << " with the cells " 
-              << ASTInfo::instance()->debugIndex
-              << " and "
-              << (ASTInfo::instance()->debugIndex - 1)
-              << " with data pointer at cell " 
-              << ASTInfo::instance()->debugIndex
-              << std::endl;
-  }
-  else
-  {
-    std::cout << "ArithmeticExpr ( " << TypeToString() << " )" << std::endl;
-  }
+    std::cout.width(level);
+    if (ArgsOptions::instance()->has_option(BO_IS_VERBOSE)) {
+	std::cout << "Arithmetic Expression - " << type_to_string() 
+		  << " with the cells " 
+		  << ASTInfo::instance()->debug_index
+		  << " and "
+		  << (ASTInfo::instance()->debug_index - 1)
+		  << " with data pointer at cell " 
+		  << ASTInfo::instance()->debug_index
+		  << std::endl;
+    }
+    else {
+	std::cout << "ArithmeticExpression ( " << type_to_string() << " )"
+		  << std::endl;
+    }
 }
 
-std::string ArithmeticExpr::TypeToString()
+std::string ArithmeticExpression::type_to_string()
 {
-  switch (_type)
-  {
+    switch (_type)
+    {
     case AT_MUL:
-    {
-      return "multiplication";
-    }
+	return "multiplication";
     case AT_DIV:
-    {
       return "division";
-    }
     case AT_REM:
-    {
       return "remainder";
     }
-  }
 }
 

--- a/src/ast/expr/ArithmeticExpr.h
+++ b/src/ast/expr/ArithmeticExpr.h
@@ -11,28 +11,46 @@
 #include <iostream>
 #include <string>
 
-#include "llvm/IR/IRBuilder.h"
-#include "llvm/IR/Module.h"
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/Module.h>
 
 #include "Expr.h"
 
+/**
+ * @brief
+ */
 typedef enum
 {
   AT_MUL,
   AT_DIV,
   AT_REM
-}ArithmeticType;
+} ArithmeticType;
 
-class ArithmeticExpr : public Expr
+/**
+ * @brief Represents the three arithmetic operations that you can use and abuse
+ * in Brain.
+ */
+class ArithmeticExpression : public Expression
 {
-  protected:
+protected:
     ArithmeticType _type;
-    std::string TypeToString();
-  public:
-    ArithmeticExpr(ArithmeticType type) : _type(type) { }
-    void CodeGen(llvm::Module *M, llvm::IRBuilder<> &B, llvm::GlobalVariable *index, llvm::GlobalVariable *cells);
-    void DebugDescription(int level);
-    ~ArithmeticExpr() {};
+    std::string type_to_string();
+public:
+    ArithmeticExpression(ArithmeticType type) : _type(type) { }
+    /**
+     * @brief
+     * @param M
+     * @param B
+     * @param index
+     * @param cells
+     */
+    void code_gen(llvm::Module *M, llvm::IRBuilder<> &B, llvm::GlobalVariable *index, llvm::GlobalVariable *cells);
+    /**
+     * @brief
+     * @param level
+     */
+    void debug_description(int level);
+    ~ArithmeticExpression() {};
 };
 
 #endif

--- a/src/ast/expr/BreakExpr.cpp
+++ b/src/ast/expr/BreakExpr.cpp
@@ -9,28 +9,26 @@
 
 using namespace llvm;
 
-void BreakExpr::CodeGen(llvm::Module *M, llvm::IRBuilder<> &B, llvm::GlobalVariable *index, llvm::GlobalVariable *cells)
+void BreakExpression::code_gen(llvm::Module *M, llvm::IRBuilder<> &B, llvm::GlobalVariable *index, llvm::GlobalVariable *cells)
 {
-  // it is not needed to create code gen for the BreakExpr
+  // it is not needed to create code gen for the BreakExpression
   // it is a terminator, so the code will stop inside the loop 
 }
 
-void BreakExpr::DebugDescription(int level)
+void BreakExpression::debug_description(int level)
 {
-  std::cout.width(level);
-  if (ArgsOptions::instance()->hasOption(BO_IS_VERBOSE))
-  {
-    std::cout << "Break Expression - data pointer at cell " 
-              << ASTInfo::instance()->debugIndex
-              << std::endl;
-  }
-  else
-  {
-    std::cout << "BreakExpr" << std::endl;
-  }
+    std::cout.width(level);
+    if (ArgsOptions::instance()->has_option(BO_IS_VERBOSE)) {
+	std::cout << "Break Expression - data pointer at cell " 
+		  << ASTInfo::instance()->debug_index
+		  << std::endl;
+    }
+    else {
+	std::cout << "BreakExpression" << std::endl;
+    }
 }
 
-ExpressionType BreakExpr::ExprCategory()
+ExpressionType BreakExpression::expression_category()
 {
-  return ET_TERMINAL;
+    return ET_TERMINAL;
 }

--- a/src/ast/expr/BreakExpr.h
+++ b/src/ast/expr/BreakExpr.h
@@ -10,20 +10,37 @@
 
 #include <iostream>
 
-#include "llvm/Transforms/Utils/BuildLibCalls.h"
-#include "llvm/IR/IRBuilder.h"
-#include "llvm/IR/Module.h"
+#include <llvm/Transforms/Utils/BuildLibCalls.h>
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/Module.h>
 
 #include "Expr.h"
 
-class BreakExpr : public Expr
+/**
+ * @brief Class that represents the break operator in Brain.
+ */
+class BreakExpression : public Expression
 {
-  public:
-    BreakExpr() { }
-    void CodeGen(llvm::Module *M, llvm::IRBuilder<> &B, llvm::GlobalVariable *index, llvm::GlobalVariable *cells);
-    void DebugDescription(int level);
-    ExpressionType ExprCategory();
-    ~BreakExpr() {};
+public:
+    BreakExpression() { }
+    /**
+     * @brief
+     * @param M
+     * @param B
+     * @param index
+     * @param cells
+     */
+    void code_gen(llvm::Module *M, llvm::IRBuilder<> &B, llvm::GlobalVariable *index, llvm::GlobalVariable *cells);
+    /**
+     * @brief
+     * @param level
+     */ 
+    void debug_description(int level);
+    /**
+     * @brief
+     */ 
+    ExpressionType expression_category();
+    ~BreakExpression() {};
 };
 
-#endif
+#endif // BREAK_EXPR_H

--- a/src/ast/expr/DebugExpr.cpp
+++ b/src/ast/expr/DebugExpr.cpp
@@ -9,7 +9,7 @@
 
 using namespace llvm;
 
-void DebugExpr::CodeGen(llvm::Module *M, llvm::IRBuilder<> &B, llvm::GlobalVariable *index, llvm::GlobalVariable *cells)
+void DebugExpression::code_gen(llvm::Module *M, llvm::IRBuilder<> &B, llvm::GlobalVariable *index, llvm::GlobalVariable *cells)
 {
   llvm::LLVMContext &C = M->getContext();
   
@@ -35,18 +35,16 @@ void DebugExpr::CodeGen(llvm::Module *M, llvm::IRBuilder<> &B, llvm::GlobalVaria
   B.CreateCall(PrintfF, ArgsArr);
 }
 
-void DebugExpr::DebugDescription(int level)
+void DebugExpression::debug_description(int level)
 {
   std::cout.width(level);
-  if (ArgsOptions::instance()->hasOption(BO_IS_VERBOSE))
-  {
+  if (ArgsOptions::instance()->has_option(BO_IS_VERBOSE)) {
     std::cout << "Debug Expression - data pointer at cell " 
-              << ASTInfo::instance()->debugIndex
+              << ASTInfo::instance()->debug_index
               << std::endl;
   }
-  else
-  {
-    std::cout << "DebugExpr" << std::endl;
+  else {
+    std::cout << "DebugExpression" << std::endl;
   }
 }
 

--- a/src/ast/expr/DebugExpr.h
+++ b/src/ast/expr/DebugExpr.h
@@ -10,19 +10,33 @@
 
 #include <iostream>
 
-#include "llvm/Transforms/Utils/BuildLibCalls.h"
-#include "llvm/IR/IRBuilder.h"
-#include "llvm/IR/Module.h"
+#include <llvm/Transforms/Utils/BuildLibCalls.h>
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/Module.h>
 
 #include "Expr.h"
 
-class DebugExpr : public Expr
+/**
+ * @brief Class that represents the debug operator in Brain.
+ */
+class DebugExpression : public Expression
 {
-  public:
-    DebugExpr() { }
-    void CodeGen(llvm::Module *M, llvm::IRBuilder<> &B, llvm::GlobalVariable *index, llvm::GlobalVariable *cells);
-    void DebugDescription(int level);
-    ~DebugExpr() {};
+public:
+    DebugExpression() { }
+    /**
+     * @brief
+     * @param M
+     * @param B
+     * @param index
+     * @param cells
+     */
+    void code_gen(llvm::Module *M, llvm::IRBuilder<> &B, llvm::GlobalVariable *index, llvm::GlobalVariable *cells);
+    /**
+     * @brief
+     * @param level
+     */ 
+    void debug_description(int level);
+    ~DebugExpression() {};
 };
 
-#endif
+#endif // DEBUG_EXPR_H

--- a/src/ast/expr/Expr.h
+++ b/src/ast/expr/Expr.h
@@ -8,8 +8,8 @@
 #ifndef EXPR_H
 #define EXPR_H
 
-#include "llvm/IR/IRBuilder.h"
-#include "llvm/IR/Module.h"
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/Module.h>
 
 #include "../../utils/ArgsOptions.h"
 #include "../general/ASTInfo.h"
@@ -18,23 +18,47 @@
   #define CAST_TO_C_STRING castToCStr
 #else
   #define CAST_TO_C_STRING CastToCStr
-#endif
+#endif // __cast_capital__
 
+/**
+ * @brief
+ */
 typedef enum
 {
   ET_NOT_IMPORTANT,
   ET_BRANCH,
   ET_TERMINAL 
-}ExpressionType;
+} ExpressionType;
 
-class Expr
+/**
+ * @brief Abstract class in which all expressions in Brain implement from.  
+ */
+class Expression
 {
-  public:
-    virtual void CodeGen(llvm::Module *M, llvm::IRBuilder<> &B, llvm::GlobalVariable *index, llvm::GlobalVariable *cells) = 0;
-    virtual void DebugDescription(int level) = 0;
-    virtual bool UpdateExpr(char update) { return false; }
-    virtual ExpressionType ExprCategory() { return ET_NOT_IMPORTANT; }
-    virtual ~Expr() {};
+public:
+    /**
+     * @brief
+     * @param M
+     * @param B
+     * @param index
+     * @param cells
+     */
+    virtual void code_gen(llvm::Module *M, llvm::IRBuilder<> &B, llvm::GlobalVariable *index, llvm::GlobalVariable *cells) = 0;
+    /**
+     * @brief
+     * @param level
+     */
+    virtual void debug_description(int level) = 0;
+    /**
+     * @brief
+     * @param update
+     */
+    virtual bool update_expression(char update) { return false; }
+    /**
+     * @brief
+     */
+    virtual ExpressionType expression_category() { return ET_NOT_IMPORTANT; }
+    virtual ~Expression() {};
 };
 
-#endif
+#endif // EXPR_H

--- a/src/ast/expr/IfExpr.cpp
+++ b/src/ast/expr/IfExpr.cpp
@@ -7,116 +7,108 @@
 
 #include "IfExpr.h"
 
-void IfExpr::CodeGen(llvm::Module *M, llvm::IRBuilder<> &B, llvm::GlobalVariable *index, llvm::GlobalVariable *cells)
+void IfExpression::code_gen(llvm::Module *M, llvm::IRBuilder<> &B, llvm::GlobalVariable *index, llvm::GlobalVariable *cells)
 {
-  llvm::LLVMContext &C = M->getContext();
-  llvm::Function *F = B.GetInsertBlock()->getParent();
-  
-  llvm::BasicBlock *ThenBB = llvm::BasicBlock::Create(C, "ThenBody", F);
-  llvm::BasicBlock *ElseBB = nullptr;
-  llvm::BasicBlock *ContBB = llvm::BasicBlock::Create(C, "IfCont", F);
-
-  // Get the current cell adress
-  llvm::Value *IdxV = B.CreateLoad(index);
-  llvm::Value *CellPtr = B.CreateGEP(B.CreatePointerCast(cells,
-                                                   llvm::Type::getInt32Ty(C)->getPointerTo()), // Cast to int32*
+    llvm::LLVMContext &C = M->getContext();
+    llvm::Function *F = B.GetInsertBlock()->getParent();
+    
+    llvm::BasicBlock *ThenBB = llvm::BasicBlock::Create(C, "ThenBody", F);
+    llvm::BasicBlock *ElseBB = nullptr;
+    llvm::BasicBlock *ContBB = llvm::BasicBlock::Create(C, "IfCont", F);
+    
+    // Get the current cell adress
+    llvm::Value *IdxV = B.CreateLoad(index);
+    llvm::Value *CellPtr = B.CreateGEP(B.CreatePointerCast(cells,
+			       llvm::Type::getInt32Ty(C)->getPointerTo()), // Cast to int32*
                                IdxV);
-  llvm::Value *SGZeroCond = B.CreateICmpSGT(B.CreateLoad(CellPtr),
-                                           B.getInt32(0)); // is cell Signed Int Greater than Zero?
+    llvm::Value *SGZeroCond = B.CreateICmpSGT(B.CreateLoad(CellPtr),
+                               B.getInt32(0)); // is cell Signed Int Greater than Zero?
   
-  if (!_exprsElse.empty())
-  {
-    ElseBB = llvm::BasicBlock::Create(C, "ElseBody", F);
-    B.CreateCondBr(SGZeroCond, ThenBB, ElseBB);
-  }
-  else
-  {
-    B.CreateCondBr(SGZeroCond, ThenBB, ContBB);
-  }
-
-  B.SetInsertPoint(ThenBB);
-  llvm::IRBuilder<> ThenB(ThenBB);
-  for (std::vector<Expr *>::iterator it = _exprsThen.begin(); it != _exprsThen.end(); ++it)
-  {
-    if ((*it)->ExprCategory() == ET_TERMINAL)
-      break;
-
-    (*it)->CodeGen(M, ThenB, index, cells);
-  }
-  
-  ThenB.CreateBr(ContBB); // uncoditional jump
-
-  if (!_exprsElse.empty()) 
-  {
-    B.SetInsertPoint(ElseBB);
-    llvm::IRBuilder<> ElseB(ElseBB);
-    for (std::vector<Expr *>::iterator it = _exprsElse.begin(); it != _exprsElse.end(); ++it)
-    {
-      if ((*it)->ExprCategory() == ET_TERMINAL)
-        break;
-
-      (*it)->CodeGen(M, ElseB, index, cells);
+    if (!_exprs_else.empty()) {
+	ElseBB = llvm::BasicBlock::Create(C, "ElseBody", F);
+	B.CreateCondBr(SGZeroCond, ThenBB, ElseBB);
     }
-
-    ElseB.CreateBr(ContBB); // uncoditional jump
-  }
-
-  B.SetInsertPoint(ContBB);
+    else {
+	B.CreateCondBr(SGZeroCond, ThenBB, ContBB);
+    }
+    
+    B.SetInsertPoint(ThenBB);
+    llvm::IRBuilder<> ThenB(ThenBB);
+    for (std::vector<Expression *>::iterator it = _exprs_then.begin(); it != _exprs_then.end(); ++it) {
+	if ((*it)->expression_category() == ET_TERMINAL) {
+	    break;
+	}
+	
+	(*it)->code_gen(M, ThenB, index, cells);
+    }
+  
+    ThenB.CreateBr(ContBB); // uncoditional jump
+    
+    if (!_exprs_else.empty()) 
+    {
+	B.SetInsertPoint(ElseBB);
+	llvm::IRBuilder<> ElseB(ElseBB);
+	for (std::vector<Expression *>::iterator it = _exprs_else.begin(); it != _exprs_else.end(); ++it) {
+	    if ((*it)->expression_category() == ET_TERMINAL) {
+		break;
+	    }
+	    
+	    (*it)->code_gen(M, ElseB, index, cells);
+	}
+	
+	ElseB.CreateBr(ContBB); // uncoditional jump
+    }
+    
+    B.SetInsertPoint(ContBB);
 }
 
-void IfExpr::DebugDescription(int level)
+void IfExpression::debug_description(int level)
 {
-  if (ArgsOptions::instance()->hasOption(BO_IS_VERBOSE))
-  {
-    std::cout << "If Expression - THEN - if cell "
-              << ASTInfo::instance()->debugIndex
-              << " != 0 ["
-              << std::endl;
-  }
-  else
-  {
-    std::cout << "IfExpr (THEN) [" << std::endl;
-  }
-
-  for (std::vector<Expr *>::iterator it = _exprsThen.begin(); it != _exprsThen.end(); ++it)
-  {
-    std::cout << std::string(level * 2, ' ');
-    (*it)->DebugDescription(level+1);
-
-    if ((*it)->ExprCategory() == ET_TERMINAL)
-      break;
-  }
-
-  std::cout << std::string(level, ' ') << "]" << std::endl;
-
-  if (!_exprsElse.empty())
-  {
-    if (ArgsOptions::instance()->hasOption(BO_IS_VERBOSE))
-    {
-      std::cout << std::string(level, ' ') 
-                << "If Expression - ELSE - [" 
-                << std::endl;
+    if (ArgsOptions::instance()->has_option(BO_IS_VERBOSE)) {
+	std::cout << "If Expression - THEN - if cell "
+		  << ASTInfo::instance()->debug_index
+		  << " != 0 ["
+		  << std::endl;
     }
-    else
-    {
-      std::cout << std::string(level, ' ') << "IfExpr (ELSE) [" << std::endl;
+    else {
+	std::cout << "IfExpression (THEN) [" << std::endl;
     }
-
-    for (std::vector<Expr *>::iterator it = _exprsElse.begin(); it != _exprsElse.end(); ++it)
-    {
-      std::cout << std::string(level * 2, ' ');
-      (*it)->DebugDescription(level+1);
-
-      if ((*it)->ExprCategory() == ET_TERMINAL)
-        break;
+    
+    for (std::vector<Expression *>::iterator it = _exprs_then.begin(); it != _exprs_then.end(); ++it) {
+	std::cout << std::string(level * 2, ' ');
+	(*it)->debug_description(level+1);
+	
+	if ((*it)->expression_category() == ET_TERMINAL) {
+	    break;
+	}
     }
 
     std::cout << std::string(level, ' ') << "]" << std::endl;
-  }
+    
+    if (!_exprs_else.empty()) {
+	if (ArgsOptions::instance()->has_option(BO_IS_VERBOSE)) {
+	    std::cout << std::string(level, ' ') 
+		      << "If Expression - ELSE - [" 
+		      << std::endl;
+	}
+	else {
+	    std::cout << std::string(level, ' ') << "IfExpression (ELSE) [" << std::endl;
+	}
+
+	for (std::vector<Expression *>::iterator it = _exprs_else.begin(); it != _exprs_else.end(); ++it) {
+	    std::cout << std::string(level * 2, ' ');
+	    (*it)->debug_description(level+1);
+	    
+	    if ((*it)->expression_category() == ET_TERMINAL)
+		break;
+	}
+
+	std::cout << std::string(level, ' ') << "]" << std::endl;
+    }
 }
 
-ExpressionType IfExpr::ExprCategory()
+ExpressionType IfExpression::expression_category()
 {
-  return ET_BRANCH;
+    return ET_BRANCH;
 }
 

--- a/src/ast/expr/IfExpr.h
+++ b/src/ast/expr/IfExpr.h
@@ -11,24 +11,45 @@
 #include <vector>
 #include <iostream>
 
-#include "llvm/IR/IRBuilder.h"
-#include "llvm/IR/Module.h"
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/Module.h>
 
 #include "Expr.h"
 
-class IfExpr : public Expr
+/**
+ * @brief Class that represents the if operator in Brain.
+ */
+class IfExpression : public Expression
 {
-  protected:
-    std::vector<Expr *> _exprsThen;
-    std::vector<Expr *> _exprsElse;
-  public:
-    IfExpr(std::vector<Expr *> exprsThen) : _exprsThen(exprsThen) { }
-    void SetElse(std::vector<Expr *> exprsElse) { _exprsElse = exprsElse; } 
-    void CodeGen(llvm::Module *M, llvm::IRBuilder<> &B, llvm::GlobalVariable *index, llvm::GlobalVariable *cells);
-    ExpressionType ExprCategory();
-    void DebugDescription(int level);
-    ~IfExpr() {};
+protected:
+    std::vector<Expression *> _exprs_then;
+    std::vector<Expression *> _exprs_else;
+public:
+    IfExpression(std::vector<Expression *> exprs_then) : _exprs_then(exprs_then) { }
+    /**
+     * @brief
+     * @param exprs_else
+     */
+    void set_else(std::vector<Expression *> exprs_else) { _exprs_else = exprs_else; }
+    /**
+     * @brief
+     * @param M
+     * @param B
+     * @param index
+     * @param cells
+     */
+    void code_gen(llvm::Module *M, llvm::IRBuilder<> &B, llvm::GlobalVariable *index, llvm::GlobalVariable *cells);
+    /**
+     * @brief
+     */
+    ExpressionType expression_category();
+    /**
+     * @brief
+     * @param level
+     */
+    void debug_description(int level);
+    ~IfExpression() {};
 };
 
-#endif
+#endif // IF_EXPR_H
 

--- a/src/ast/expr/IncrementExpr.cpp
+++ b/src/ast/expr/IncrementExpr.cpp
@@ -7,7 +7,7 @@
 
 #include "IncrementExpr.h"
 
-void IncrementExpr::CodeGen(llvm::Module *M, llvm::IRBuilder<> &B, llvm::GlobalVariable *index, llvm::GlobalVariable *cells)
+void IncrementExpression::code_gen(llvm::Module *M, llvm::IRBuilder<> &B, llvm::GlobalVariable *index, llvm::GlobalVariable *cells)
 {
   llvm::Value* Idxs[] = { B.getInt32(0), B.CreateLoad(index) };
   llvm::ArrayRef<llvm::Value *> IdxsArr(Idxs);
@@ -18,30 +18,34 @@ void IncrementExpr::CodeGen(llvm::Module *M, llvm::IRBuilder<> &B, llvm::GlobalV
   B.CreateStore(B.CreateAdd(CellV, B.getInt32(_increment)), CellPtr);
 }
 
-void IncrementExpr::DebugDescription(int level)
+void IncrementExpression::debug_description(int level)
 {
-  std::cout.width(level);
-  if (ArgsOptions::instance()->hasOption(BO_IS_VERBOSE))
-  {
-    std::cout << "Increment Expression - increment of "
-              << _increment
-              << " with data pointer at cell "
-              << ASTInfo::instance()->debugIndex
-              << std::endl;
-  }
-  else
-  {
-    std::cout << "IncrementExpr (" << _increment << ")" << std::endl;
-  }
+    std::cout.width(level);
+    if (ArgsOptions::instance()->has_option(BO_IS_VERBOSE)) {
+	std::cout << "Increment Expression - increment of "
+		  << _increment
+		  << " with data pointer at cell "
+		  << ASTInfo::instance()->debug_index
+		  << std::endl;
+    }
+    else
+    {
+	std::cout << "IncrementExpression (" << _increment << ")" << std::endl;
+    }
 }
 
-bool IncrementExpr::UpdateExpr(char update)
+bool IncrementExpression::update_expression(char update)
 {
-  switch (update)
-  {
-    case '+': _increment++; return true;
-    case '-': _increment--; return true;
-    default : return false;
-  } 
+    switch (update)
+    {
+    case '+':
+	_increment++;
+	return true;
+    case '-':
+	_increment--;
+	return true;
+    default :
+	return false;
+    } 
 }
 

--- a/src/ast/expr/IncrementExpr.h
+++ b/src/ast/expr/IncrementExpr.h
@@ -10,21 +10,35 @@
 
 #include <iostream>
 
-#include "llvm/IR/IRBuilder.h"
-#include "llvm/IR/Module.h"
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/Module.h>
 
 #include "Expr.h"
 
-class IncrementExpr : public Expr
+/**
+ * @brief Class that represent the increment operator in Brain.
+ */
+class IncrementExpression : public Expression
 {
-  protected:
+protected:
     int _increment;
-  public:
-    IncrementExpr(int increment) : _increment(increment) { }
-    void CodeGen(llvm::Module *M, llvm::IRBuilder<> &B, llvm::GlobalVariable *index, llvm::GlobalVariable *cells);
-    void DebugDescription(int level);
-    bool UpdateExpr(char update);
-    ~IncrementExpr() {};
+public:
+    IncrementExpression(int increment) : _increment(increment) { }
+    /**
+     * @brief
+     */
+    void code_gen(llvm::Module *M, llvm::IRBuilder<> &B, llvm::GlobalVariable *index, llvm::GlobalVariable *cells);
+    /**
+     * @brief
+     * @param level
+     */
+    void debug_description(int level);
+    /**
+     * @brief
+     * @param update
+     */
+    bool update_expression(char update);
+    ~IncrementExpression() {};
 };
 
-#endif
+#endif // INCREMENT_EXPR_H

--- a/src/ast/expr/InputExpr.cpp
+++ b/src/ast/expr/InputExpr.cpp
@@ -9,49 +9,46 @@
 
 using namespace llvm;
 
-void InputExpr::CodeGen(llvm::Module *M, llvm::IRBuilder<> &B, llvm::GlobalVariable *index, llvm::GlobalVariable *cells)
+void InputExpression::code_gen(llvm::Module *M, llvm::IRBuilder<> &B, llvm::GlobalVariable *index, llvm::GlobalVariable *cells)
 {
-  llvm::LLVMContext &C = M->getContext();
+    llvm::LLVMContext &C = M->getContext();
   
-  // Get "scanf" function
-  // i32 @scanf(i8*, ...)
-  llvm::Type* ScanfArgs[] = { llvm::Type::getInt8PtrTy(C) };
-  llvm::FunctionType *ScanfTy = llvm::FunctionType::get(llvm::Type::getInt32Ty(C), ScanfArgs, true /* vaarg */);
-  llvm::Function *ScanfF = llvm::cast<llvm::Function>(M->getOrInsertFunction("scanf", ScanfTy));
+    // Get "scanf" function
+    // i32 @scanf(i8*, ...)
+    llvm::Type* ScanfArgs[] = { llvm::Type::getInt8PtrTy(C) };
+    llvm::FunctionType *ScanfTy = llvm::FunctionType::get(llvm::Type::getInt32Ty(C), ScanfArgs, true /* vaarg */);
+    llvm::Function *ScanfF = llvm::cast<llvm::Function>(M->getOrInsertFunction("scanf", ScanfTy));
+    
+    // Prepare args
+    static llvm::Value *GScanfFormat = NULL;
+    if (!GScanfFormat) {
+	GScanfFormat = B.CreateGlobalString(" %c", "brainf.scanf.format");
+    }
+    llvm::Value *IntPtr = B.CreateAlloca(llvm::Type::getInt32Ty(C));
   
-  // Prepare args
-  static llvm::Value *GScanfFormat = NULL;
-  if (!GScanfFormat) 
-  {
-    GScanfFormat = B.CreateGlobalString(" %c", "brainf.scanf.format");
-  }
-  llvm::Value *IntPtr = B.CreateAlloca(llvm::Type::getInt32Ty(C));
-  
-  // Call "scanf"
-  llvm::Value* Args[] = { CAST_TO_C_STRING(GScanfFormat, B), IntPtr };
-  llvm::ArrayRef<llvm::Value *> ArgsArr(Args);
-  B.CreateCall(ScanfF, ArgsArr);
-	
-  llvm::Value *IdxV = B.CreateLoad(index);
-  llvm::Value *CellPtr = B.CreateGEP(B.CreatePointerCast(cells,
+    // Call "scanf"
+    llvm::Value* Args[] = { CAST_TO_C_STRING(GScanfFormat, B), IntPtr };
+    llvm::ArrayRef<llvm::Value *> ArgsArr(Args);
+    B.CreateCall(ScanfF, ArgsArr);
+    
+    llvm::Value *IdxV = B.CreateLoad(index);
+    llvm::Value *CellPtr = B.CreateGEP(B.CreatePointerCast(cells,
                                                    llvm::Type::getInt32Ty(C)->getPointerTo()), // Cast to int32*
                                IdxV);
-  // Save the new value to current cell
-  B.CreateStore(B.CreateLoad(IntPtr), CellPtr);
+    // Save the new value to current cell
+    B.CreateStore(B.CreateLoad(IntPtr), CellPtr);
 }
 
-void InputExpr::DebugDescription(int level)
+void InputExpression::debug_description(int level)
 {
-  std::cout.width(level);
-  if (ArgsOptions::instance()->hasOption(BO_IS_VERBOSE))
-  {
-    std::cout << "Input Expression - read char with data pointer at cell " 
-              << ASTInfo::instance()->debugIndex
-              << std::endl;
-  }
-  else
-  {
-    std::cout << "InputExpr" << std::endl;
-  }
+    std::cout.width(level);
+    if (ArgsOptions::instance()->has_option(BO_IS_VERBOSE)) {
+	std::cout << "Input Expression - read char with data pointer at cell " 
+		  << ASTInfo::instance()->debug_index
+		  << std::endl;
+    }
+    else {
+	std::cout << "InputExpression" << std::endl;
+    }
 }
 

--- a/src/ast/expr/InputExpr.h
+++ b/src/ast/expr/InputExpr.h
@@ -10,19 +10,29 @@
 
 #include <iostream>
 
-#include "llvm/Transforms/Utils/BuildLibCalls.h"
-#include "llvm/IR/IRBuilder.h"
-#include "llvm/IR/Module.h"
+#include <llvm/Transforms/Utils/BuildLibCalls.h>
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/Module.h>
 
 #include "Expr.h"
 
-class InputExpr : public Expr
+/**
+ * @brief
+ */
+class InputExpression : public Expression
 {
-  public:
-    InputExpr() { }
-    void CodeGen(llvm::Module *M, llvm::IRBuilder<> &B, llvm::GlobalVariable *index, llvm::GlobalVariable *cells);
-    void DebugDescription(int level);
-    ~InputExpr() {};
+public:
+    InputExpression() { }
+    /**
+     * @brief
+     */
+    void code_gen(llvm::Module *M, llvm::IRBuilder<> &B, llvm::GlobalVariable *index, llvm::GlobalVariable *cells);
+    /**
+     * @brief
+     * @param level 
+     */
+    void debug_description(int level);
+    ~InputExpression() {};
 };
 
-#endif
+#endif // INPUT_EXPR_H

--- a/src/ast/expr/LoopExpr.cpp
+++ b/src/ast/expr/LoopExpr.cpp
@@ -7,104 +7,99 @@
 
 #include "LoopExpr.h"
 
-void LoopExpr::CodeGen(llvm::Module *M, llvm::IRBuilder<> &B, llvm::GlobalVariable *index, llvm::GlobalVariable *cells)
+void LoopExpression::code_gen(llvm::Module *M, llvm::IRBuilder<> &B, llvm::GlobalVariable *index, llvm::GlobalVariable *cells)
 {
-  llvm::LLVMContext &C = M->getContext();
+    llvm::LLVMContext &C = M->getContext();
   
-  // Create a basic block for loop
-  llvm::Function *F = B.GetInsertBlock()->getParent();
-  llvm::BasicBlock *StartBB = llvm::BasicBlock::Create(C, "LoopStart", F);
-  
-  llvm::Value *IdxV = nullptr; 
-  llvm::Value *CellPtr = nullptr; 
-  llvm::Value *CounterV = nullptr;
-  if (_type == LT_FOR)
-  {
-    // Get the current cell adress
-    IdxV = B.CreateLoad(index);
-    CellPtr = B.CreateGEP(B.CreatePointerCast(cells,
+    // Create a basic block for loop
+    llvm::Function *F = B.GetInsertBlock()->getParent();
+    llvm::BasicBlock *StartBB = llvm::BasicBlock::Create(C, "LoopStart", F);
+    
+    llvm::Value *IdxV = nullptr; 
+    llvm::Value *CellPtr = nullptr; 
+    llvm::Value *CounterV = nullptr;
+    
+    if (_type == LT_FOR) {
+	// Get the current cell adress
+	IdxV = B.CreateLoad(index);
+	CellPtr = B.CreateGEP(B.CreatePointerCast(cells,
                                                    llvm::Type::getInt32Ty(C)->getPointerTo()), // Cast to int32*
                                IdxV);
-    CounterV = B.CreateAlloca(llvm::Type::getInt32Ty(C), 0, "counter");
-    B.CreateStore(B.CreateLoad(CellPtr), CounterV);
-  }
+	CounterV = B.CreateAlloca(llvm::Type::getInt32Ty(C), 0, "counter");
+	B.CreateStore(B.CreateLoad(CellPtr), CounterV);
+    }
 
-  B.CreateBr(StartBB);
-  
-  B.SetInsertPoint(StartBB);
-  llvm::IRBuilder<> StartB(StartBB);
-  
-  // Enter the block ("LoopBody") if current cell value > 0, else skip the loop (i.e.: go to "LoopEnd")
-  llvm::BasicBlock *LoopBB = llvm::BasicBlock::Create(C, "LoopBody", F);
-  llvm::BasicBlock *EndBB = llvm::BasicBlock::Create(C, "LoopEnd", F);
-  
-  llvm::Value *SGZeroCond = nullptr;
-  if (_type == LT_FOR)
-  {
-    SGZeroCond = StartB.CreateICmpSGT(StartB.CreateLoad(CounterV),
+    B.CreateBr(StartBB);
+    
+    B.SetInsertPoint(StartBB);
+    llvm::IRBuilder<> StartB(StartBB);
+    
+    // Enter the block ("LoopBody") if current cell value > 0, else skip the loop (i.e.: go to "LoopEnd")
+    llvm::BasicBlock *LoopBB = llvm::BasicBlock::Create(C, "LoopBody", F);
+    llvm::BasicBlock *EndBB = llvm::BasicBlock::Create(C, "LoopEnd", F);
+    
+    llvm::Value *SGZeroCond = nullptr;
+    if (_type == LT_FOR) {
+	SGZeroCond = StartB.CreateICmpSGT(StartB.CreateLoad(CounterV),
+					  StartB.getInt32(0)); // is cell Signed Int Greater than Zero?
+    }
+    else {
+	// Get the current cell adress
+	IdxV = B.CreateLoad(index);
+	CellPtr = B.CreateGEP(B.CreatePointerCast(cells,
+						  llvm::Type::getInt32Ty(C)->getPointerTo()), // Cast to int32*
+			      IdxV);
+	SGZeroCond = StartB.CreateICmpSGT(StartB.CreateLoad(CellPtr),
                                            StartB.getInt32(0)); // is cell Signed Int Greater than Zero?
-  }
-  else
-  {
-    // Get the current cell adress
-    IdxV = B.CreateLoad(index);
-    CellPtr = B.CreateGEP(B.CreatePointerCast(cells,
-                                                   llvm::Type::getInt32Ty(C)->getPointerTo()), // Cast to int32*
-                               IdxV);
-    SGZeroCond = StartB.CreateICmpSGT(StartB.CreateLoad(CellPtr),
-                                           StartB.getInt32(0)); // is cell Signed Int Greater than Zero?
-  }
+    }
 
-  StartB.CreateCondBr(SGZeroCond, LoopBB, EndBB);
+    StartB.CreateCondBr(SGZeroCond, LoopBB, EndBB);
   
-  B.SetInsertPoint(LoopBB);
-  llvm::IRBuilder<> LoopB(LoopBB);
-  // Recursively generate code (into "LoopBody" block)
-  for (std::vector<Expr *>::iterator it = _exprs.begin(); it != _exprs.end(); ++it)
-  {
-    if ((*it)->ExprCategory() == ET_TERMINAL)
-      break;
+    B.SetInsertPoint(LoopBB);
+    llvm::IRBuilder<> LoopB(LoopBB);
+    // Recursively generate code (into "LoopBody" block)
+    for (std::vector<Expression *>::iterator it = _exprs.begin(); it != _exprs.end(); ++it) {
+	if ((*it)->expression_category() == ET_TERMINAL) {
+	    break;
+	}
+	
+	(*it)->code_gen(M, LoopB, index, cells);
+    }
 
-    (*it)->CodeGen(M, LoopB, index, cells);
-  }
-
-  if (_type == LT_FOR)
-  {
-    LoopB.CreateStore(LoopB.CreateAdd(LoopB.CreateLoad(CounterV), LoopB.getInt32(-1)), CounterV);
-  }
+    if (_type == LT_FOR) {
+	LoopB.CreateStore(LoopB.CreateAdd(LoopB.CreateLoad(CounterV), LoopB.getInt32(-1)), CounterV);
+    }
   
-  LoopB.CreateBr(StartBB); // Restart loop (will next exit if current cell value > 0)
+    LoopB.CreateBr(StartBB); // Restart loop (will next exit if current cell value > 0)
   
-  B.SetInsertPoint(EndBB);
+    B.SetInsertPoint(EndBB);
 }
 
-void LoopExpr::DebugDescription(int level)
+void LoopExpression::debug_description(int level)
 {
-  std::string openedBrackets = (_type == LT_FOR) ? "{" : "[";
-  std::string closedBrackets = (_type == LT_FOR) ? "}" : "]";  
+    std::string openedBrackets = (_type == LT_FOR) ? "{" : "[";
+    std::string closedBrackets = (_type == LT_FOR) ? "}" : "]";  
 
-  if (ArgsOptions::instance()->hasOption(BO_IS_VERBOSE))
-  {
-    std::cout << "Loop Expression - "
-              << "data point at cell "
-              << ASTInfo::instance()->debugIndex 
-              << openedBrackets 
-              << std::endl; 
-  }
-  else
-  {
-    std::cout << "LoopExpr: " << openedBrackets << std::endl;
-  }
+    if (ArgsOptions::instance()->has_option(BO_IS_VERBOSE)) {
+	std::cout << "Loop Expression - "
+		  << "data point at cell "
+		  << ASTInfo::instance()->debug_index 
+		  << openedBrackets 
+		  << std::endl; 
+    }
+    else {
+	std::cout << "LoopExpression: " << openedBrackets << std::endl;
+    }
 
-  for (std::vector<Expr *>::iterator it = _exprs.begin(); it != _exprs.end(); ++it)
-  {
-    std::cout << std::string(level * 2, ' ');
-    (*it)->DebugDescription(level+1);
+    for (std::vector<Expression *>::iterator it = _exprs.begin(); it != _exprs.end(); ++it) {
+	std::cout << std::string(level * 2, ' ');
+	(*it)->debug_description(level+1);
+    
+	if ((*it)->expression_category() == ET_TERMINAL) {
+	    break;
+	}
+    }
 
-    if ((*it)->ExprCategory() == ET_TERMINAL)
-      break;
-  }
-
-  std::cout << std::string(level, ' ') << closedBrackets << std::endl;
+    std::cout << std::string(level, ' ') << closedBrackets << std::endl;
 }
 

--- a/src/ast/expr/LoopExpr.h
+++ b/src/ast/expr/LoopExpr.h
@@ -11,27 +11,41 @@
 #include <vector>
 #include <iostream>
 
-#include "llvm/IR/IRBuilder.h"
-#include "llvm/IR/Module.h"
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/Module.h>
 
 #include "Expr.h"
 
+/**
+ * @brief 
+ */
 typedef enum
 {
   LT_WHILE,
   LT_FOR
-}LoopType;
+} LoopType;
 
-class LoopExpr : public Expr
+
+/**
+ * @brief Class that represents the loop operator in Brain.
+ */
+class LoopExpression : public Expression
 {
-  protected:
-    std::vector<Expr *> _exprs;
+protected:
+    std::vector<Expression *> _exprs;
     LoopType _type;
-  public:
-    LoopExpr(std::vector<Expr *> exprs, LoopType type) : _exprs(exprs), _type(type) { }
-    void CodeGen(llvm::Module *M, llvm::IRBuilder<> &B, llvm::GlobalVariable *index, llvm::GlobalVariable *cells);
-    void DebugDescription(int level);
-    ~LoopExpr() {};
+public:
+    LoopExpression(std::vector<Expression *> exprs, LoopType type) : _exprs(exprs), _type(type) { }
+    /**
+     * @brief
+     */
+    void code_gen(llvm::Module *M, llvm::IRBuilder<> &B, llvm::GlobalVariable *index, llvm::GlobalVariable *cells);
+    /**
+     * @brief
+     * @param level
+     */
+    void debug_description(int level);
+    ~LoopExpression() {};
 };
 
 #endif

--- a/src/ast/expr/OutputExpr.cpp
+++ b/src/ast/expr/OutputExpr.cpp
@@ -9,44 +9,43 @@
 
 using namespace llvm;
 
-void OutputExpr::CodeGen(llvm::Module *M, llvm::IRBuilder<> &B, llvm::GlobalVariable *index, llvm::GlobalVariable *cells)
+void OutputExpression::code_gen(llvm::Module *M, llvm::IRBuilder<> &B, llvm::GlobalVariable *index, llvm::GlobalVariable *cells)
 {
-  llvm::LLVMContext &C = M->getContext();
+    llvm::LLVMContext &C = M->getContext();
   
-  // Get "printf" function
-  // i32 @printf(i8*, ...)
-  llvm::Type* PrintfArgs[] = { llvm::Type::getInt8PtrTy(C) };
-  llvm::FunctionType *PrintfTy = llvm::FunctionType::get(llvm::Type::getInt32Ty(C), PrintfArgs, true /* vaarg */);
-  llvm::Function *PrintfF = llvm::cast<llvm::Function>(M->getOrInsertFunction("printf", PrintfTy));
+    // Get "printf" function
+    // i32 @printf(i8*, ...)
+    llvm::Type* PrintfArgs[] = { llvm::Type::getInt8PtrTy(C) };
+    llvm::FunctionType *PrintfTy = llvm::FunctionType::get(llvm::Type::getInt32Ty(C), PrintfArgs, true /* vaarg */);
+    llvm::Function *PrintfF = llvm::cast<llvm::Function>(M->getOrInsertFunction("printf", PrintfTy));
   
-  // Prepare args
-  static llvm::Value *GPrintfFormat = NULL;
-  if (!GPrintfFormat) {
-    GPrintfFormat = B.CreateGlobalString("%c", "brainf.printf.format");
-  }
-  llvm::Value *IdxV = B.CreateLoad(index);
-  llvm::Value *CellPtr = B.CreateGEP(B.CreatePointerCast(cells,
+    // Prepare args
+    static llvm::Value *GPrintfFormat = NULL;
+    if (!GPrintfFormat) {
+	GPrintfFormat = B.CreateGlobalString("%c", "brainf.printf.format");
+    }
+    
+    llvm::Value *IdxV = B.CreateLoad(index);
+    llvm::Value *CellPtr = B.CreateGEP(B.CreatePointerCast(cells,
                                                    llvm::Type::getInt32Ty(C)->getPointerTo()), // Cast to int32*
                                IdxV);
   
-  // Call "printf"
-  llvm::Value* Args[] = { CAST_TO_C_STRING(GPrintfFormat, B), B.CreateLoad(CellPtr) };
-  llvm::ArrayRef<llvm::Value *> ArgsArr(Args);
-  B.CreateCall(PrintfF, ArgsArr);
+    // Call "printf"
+    llvm::Value* Args[] = { CAST_TO_C_STRING(GPrintfFormat, B), B.CreateLoad(CellPtr) };
+    llvm::ArrayRef<llvm::Value *> ArgsArr(Args);
+    B.CreateCall(PrintfF, ArgsArr);
 }
 
-void OutputExpr::DebugDescription(int level)
+void OutputExpression::debug_description(int level)
 {
-  std::cout.width(level);
-  if (ArgsOptions::instance()->hasOption(BO_IS_VERBOSE))
-  {
-    std::cout << "Output Expression - print out char with data pointer at cell "
-              << ASTInfo::instance()->debugIndex
-              << std::endl;
-  }
-  else
-  {
-    std::cout << "OutputExpr" << std::endl;
-  }
+    std::cout.width(level);
+    if (ArgsOptions::instance()->has_option(BO_IS_VERBOSE)) {
+	std::cout << "Output Expression - print out char with data pointer at cell "
+		  << ASTInfo::instance()->debug_index
+		  << std::endl;
+    }
+    else {
+	std::cout << "OutputExpr" << std::endl;
+    }
 }
 

--- a/src/ast/expr/OutputExpr.h
+++ b/src/ast/expr/OutputExpr.h
@@ -10,19 +10,29 @@
 
 #include <iostream>
 
-#include "llvm/Transforms/Utils/BuildLibCalls.h"
-#include "llvm/IR/IRBuilder.h"
-#include "llvm/IR/Module.h"
+#include <llvm/Transforms/Utils/BuildLibCalls.h>
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/Module.h>
 
 #include "Expr.h"
 
-class OutputExpr : public Expr
+/**
+ * @brief Class that represents the output operator in Brain.
+ */
+class OutputExpression : public Expression
 {
-  public:
-    OutputExpr() { }
-    void CodeGen(llvm::Module *M, llvm::IRBuilder<> &B, llvm::GlobalVariable *index, llvm::GlobalVariable *cells);
-    void DebugDescription(int level);
-    ~OutputExpr() {};
+public:
+    OutputExpression() { }
+    /**
+     * @brief
+     */
+    void code_gen(llvm::Module *M, llvm::IRBuilder<> &B, llvm::GlobalVariable *index, llvm::GlobalVariable *cells);
+    /**
+     * @brief
+     * @param level
+     */ 
+    void debug_description(int level);
+    ~OutputExpression() {};
 };
 
-#endif
+#endif // OUTPUT_EXPR_H

--- a/src/ast/expr/ShiftExpr.cpp
+++ b/src/ast/expr/ShiftExpr.cpp
@@ -7,43 +7,46 @@
 
 #include "ShiftExpr.h"
 
-void ShiftExpr::CodeGen(llvm::Module *M, llvm::IRBuilder<> &B, llvm::GlobalVariable *index, llvm::GlobalVariable *cells)
+void ShiftExpression::code_gen(llvm::Module *M, llvm::IRBuilder<> &B, llvm::GlobalVariable *index, llvm::GlobalVariable *cells)
 {
-  // Load index value
-  llvm::Value *IdxV = B.CreateLoad(index);
-  // Add |_step| to index and save the value
-  B.CreateStore(B.CreateAdd(IdxV, B.getInt32(_step)), index);
+    // Load index value
+    llvm::Value *IdxV = B.CreateLoad(index);
+    // Add |_step| to index and save the value
+    B.CreateStore(B.CreateAdd(IdxV, B.getInt32(_step)), index);
 }
 
-void ShiftExpr::DebugDescription(int level)
+void ShiftExpression::debug_description(int level)
 {
-  std::cout.width(level);
-  if (ArgsOptions::instance()->hasOption(BO_IS_VERBOSE))
-  {
-    std::cout << "Shift Expression - move data pointer from "
-              << ASTInfo::instance()->debugIndex
-              << " to "
-              << ASTInfo::instance()->debugIndex + _step
-              << " - "
-              << _step
-              << " step(s)"
-              << std::endl;
-  }
-  else
-  {
-    std::cout << "ShiftExpr (" << _step << ")" << std::endl;
-  }
+    std::cout.width(level);
+    if (ArgsOptions::instance()->has_option(BO_IS_VERBOSE)) {
+	std::cout << "Shift Expression - move data pointer from "
+		  << ASTInfo::instance()->debug_index
+		  << " to "
+		  << ASTInfo::instance()->debug_index + _step
+		  << " - "
+		  << _step
+		  << " step(s)"
+		  << std::endl;
+    }
+    else {
+	std::cout << "ShiftExpression (" << _step << ")" << std::endl;
+    }
 
-  ASTInfo::instance()->debugIndex += _step;
+    ASTInfo::instance()->debug_index += _step;
 }
 
-bool ShiftExpr::UpdateExpr(char update)
+bool ShiftExpression::update_expression(char update)
 {
-  switch(update)
-  {
-    case '>': _step++; return true;
-    case '<': _step--; return true;
-    default : return false;
-  }
+    switch(update)
+    {
+    case '>':
+	_step++;
+	return true;
+    case '<':
+	_step--;
+	return true;
+    default :
+	return false;
+    }
 }
 

--- a/src/ast/expr/ShiftExpr.h
+++ b/src/ast/expr/ShiftExpr.h
@@ -10,21 +10,35 @@
 
 #include <iostream>
 
-#include "llvm/IR/IRBuilder.h"
-#include "llvm/IR/Module.h"
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/Module.h>
 
 #include "Expr.h"
 
-class ShiftExpr : public Expr
+/**
+ * @brief Class that represents the shift operator in Brain.
+ */
+class ShiftExpression : public Expression
 {
-  protected:
+protected:
     int _step;
-  public:
-    ShiftExpr(int step) : _step(step) { }
-    void CodeGen(llvm::Module *M, llvm::IRBuilder<> &B, llvm::GlobalVariable *index, llvm::GlobalVariable *cells);
-    void DebugDescription(int level);
-    bool UpdateExpr(char update);
-    ~ShiftExpr() {};
+public:
+    ShiftExpression(int step) : _step(step) { }
+    /**
+     * @brief
+     */
+    void code_gen(llvm::Module *M, llvm::IRBuilder<> &B, llvm::GlobalVariable *index, llvm::GlobalVariable *cells);
+    /**
+     * @brief
+     * @param level
+     */
+    void debug_description(int level);
+    /**
+     * @brief
+     * @param level
+     */
+    bool update_expression(char update);
+    ~ShiftExpression() {};
 };
 
-#endif
+#endif // SHIFT_EXPR_H

--- a/src/ast/general/ASTInfo.cpp
+++ b/src/ast/general/ASTInfo.cpp
@@ -11,7 +11,9 @@ ASTInfo *ASTInfo::_instance = nullptr;
 
 ASTInfo* ASTInfo::instance()
 {
-  if (!ASTInfo::_instance)
+  if (!ASTInfo::_instance) {
     ASTInfo::_instance = new ASTInfo();
+  }
+  
   return _instance;
 }

--- a/src/ast/general/ASTInfo.h
+++ b/src/ast/general/ASTInfo.h
@@ -8,17 +8,27 @@
 #ifndef AST_INFO_H
 #define AST_INFO_H
 
+/**
+ * @brief
+ */
 class ASTInfo 
 {
-  private:
-    ASTInfo() : debugIndex(0) {}
+private:
+    /**
+     * @brief Private constructor of ASTInfo, denoting that this is a Singleton.
+     */
+    ASTInfo() : debug_index(0) {}
     static ASTInfo *_instance;
-  public:
-    long debugIndex;
+public:
+    long debug_index;
     ASTInfo(ASTInfo const&) = delete;
     ASTInfo& operator=(ASTInfo const&) = delete;
+    /**
+     * @brief Returns the instance of ASTInfo class if the member _instance is 
+     * nullptr, otherwise it creates a new ASTInfo object and returns it.
+     */
     static ASTInfo* instance();
 };
 
-#endif
+#endif // AST_INFO_H
 

--- a/src/brain.cpp
+++ b/src/brain.cpp
@@ -9,19 +9,19 @@
 #include <iostream>
 #include <vector>
 
-#include "llvm/ExecutionEngine/SectionMemoryManager.h"
-#include "llvm/ExecutionEngine/ExecutionEngine.h"
-#include "llvm/ExecutionEngine/GenericValue.h"
-#include "llvm/ExecutionEngine/MCJIT.h"
+#include <llvm/ExecutionEngine/SectionMemoryManager.h>
+#include <llvm/ExecutionEngine/ExecutionEngine.h>
+#include <llvm/ExecutionEngine/GenericValue.h>
+#include <llvm/ExecutionEngine/MCJIT.h>
 
-#include "llvm/Support/ManagedStatic.h"
-#include "llvm/Support/TargetSelect.h"
-#include "llvm/Support/raw_ostream.h"
+#include <llvm/Support/ManagedStatic.h>
+#include <llvm/Support/TargetSelect.h>
+#include <llvm/Support/raw_ostream.h>
 
-#include "llvm/IR/LLVMContext.h"
-#include "llvm/IR/IRBuilder.h"
-#include "llvm/IR/Module.h"
-#include "llvm/IR/Value.h"
+#include <llvm/IR/LLVMContext.h>
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/Module.h>
+#include <llvm/IR/Value.h>
 
 #include "parser/Parser.h"
 #include "utils/ArgsHandler.h"
@@ -29,79 +29,78 @@
 
 #define MODULE_NAME "brainModule"
 
-int main(int argc, char *argv[])
+int main(int argc, char **argv)
 {
-  ArgsHandler argsHandler(argc, argv);
-  Parser parser(argsHandler.getStringFile());
+    ArgsHandler args_handler(argc, argv);
+    Parser parser(args_handler.get_string_file());
  
-  // Create the context and the module
-  llvm::LLVMContext C;
-  llvm::ErrorOr<llvm::Module *> ModuleOrErr = new llvm::Module(MODULE_NAME, C);
-  std::unique_ptr<llvm::Module> Owner = std::unique_ptr<llvm::Module>(ModuleOrErr.get());
-  llvm::Module *M = Owner.get();
-
-  // Create the main function: "i32 @main()"
-  llvm::Function *MainF = llvm::cast<llvm::Function>(M->getOrInsertFunction("main", llvm::Type::getInt32Ty(C), (llvm::Type *)0));
-
-  // Create the entry block
-  llvm::BasicBlock *BB = llvm::BasicBlock::Create(C,
+    // Create the context and the module
+    llvm::LLVMContext C;
+    llvm::ErrorOr<llvm::Module *> ModuleOrErr = new llvm::Module(MODULE_NAME, C);
+    std::unique_ptr<llvm::Module> Owner = std::unique_ptr<llvm::Module>(ModuleOrErr.get());
+    llvm::Module *M = Owner.get();
+    
+    // Create the main function: "i32 @main()"
+    llvm::Function *MainF = llvm::cast<llvm::Function>(M->getOrInsertFunction("main", llvm::Type::getInt32Ty(C), (llvm::Type *)0));
+    
+    // Create the entry block
+    llvm::BasicBlock *BB = llvm::BasicBlock::Create(C,
                                       "EntryBlock", // Conventionnaly called "EntryBlock"
                                       MainF // Add it to "main" function
                                       );
-  llvm::IRBuilder<> B(BB); // Create a builder to add instructions
-  B.SetInsertPoint(BB); // Insert the block to function
+    llvm::IRBuilder<> B(BB); // Create a builder to add instructions
+    B.SetInsertPoint(BB); // Insert the block to function
 
-  // Generate IR code from parser
-  parser.CodeGen(M, B);
+    // Generate IR code from parser
+    parser.code_gen(M, B);
   
-  // Return 0 to the "main" function
-  B.CreateRet(B.getInt32(0));
+    // Return 0 to the "main" function
+    B.CreateRet(B.getInt32(0));
+    
+    if (ArgsOptions::instance()->has_option(BO_IS_EMITTING_AST)) {
+	std::cout << "\n" << "=== Debug Information ===" << "\n";
+	parser.debug_description(0);
+    }
 
-  if (ArgsOptions::instance()->hasOption(BO_IS_EMITTING_AST))
-  {
-    std::cout << "\n" << "=== Debug Information ===" << "\n";
-    parser.DebugDescription(0);
-  }
+    if (ArgsOptions::instance()->has_option(BO_IS_EMITTING_LLVM)) { 
+	std::cout << "\n" << "=== LLVM IR ===" << "\n"; 
+	// Print (dump) the module
+	M->dump();
+    }
+    
+    // Default initialisation
+    llvm::InitializeNativeTarget();
+    llvm::InitializeNativeTargetAsmPrinter();
+    llvm::InitializeNativeTargetAsmParser();
+    
+    // Create the execution engine
+    std::string ErrStr;
+    llvm::EngineBuilder *EB = new llvm::EngineBuilder(std::move(Owner));
+    llvm::ExecutionEngine *EE = EB->setErrorStr(&ErrStr)
+	.setMCJITMemoryManager(std::unique_ptr<llvm::SectionMemoryManager>(new llvm::SectionMemoryManager()))
+	.create();
+    
+    if (!ErrStr.empty()) {
+	std::cout << ErrStr << std::endl;
+	exit(0);
+    }
 
-  if(ArgsOptions::instance()->hasOption(BO_IS_EMITTING_LLVM))
-  { 
-    std::cout << "\n" << "=== LLVM IR ===" << "\n"; 
-    // Print (dump) the module
-    M->dump();
-  }
- 
-  // Default initialisation
-  llvm::InitializeNativeTarget();
-  llvm::InitializeNativeTargetAsmPrinter();
-  llvm::InitializeNativeTargetAsmParser();
- 
-  // Create the execution engine
-  std::string ErrStr;
-  llvm::EngineBuilder *EB = new llvm::EngineBuilder(std::move(Owner));
-  llvm::ExecutionEngine *EE = EB->setErrorStr(&ErrStr)
-    .setMCJITMemoryManager(std::unique_ptr<llvm::SectionMemoryManager>(new llvm::SectionMemoryManager()))
-    .create();
+    // Finalize the execution engine before use it
+    EE->finalizeObject();
 
-  if (!ErrStr.empty()) {
-    std::cout << ErrStr << "\n";
-    exit(0);
-  }
-
-  // Finalize the execution engine before use it
-  EE->finalizeObject();
-
-  if (ArgsOptions::instance()->hasOption(BO_IS_EMITTING_AST) || ArgsOptions::instance()->hasOption(BO_IS_EMITTING_LLVM))
-  {
-    // Run the program
-    std::cout << "\n" << "=== Program Output ===" << "\n";
-  }
-  std::vector<llvm::GenericValue> Args(0); // No args
-  llvm::GenericValue gv = EE->runFunction(MainF, Args);
+    if (ArgsOptions::instance()->has_option(BO_IS_EMITTING_AST) ||
+	ArgsOptions::instance()->has_option(BO_IS_EMITTING_LLVM)) {
+	// Run the program
+	std::cout << "\n" << "=== Program Output ===" << "\n";
+    }
+    
+    std::vector<llvm::GenericValue> Args(0); // No args
+    llvm::GenericValue gv = EE->runFunction(MainF, Args);
   
-  // Clean up and shutdown
-  delete EE;
-  llvm::llvm_shutdown();
+    // Clean up and shutdown
+    delete EE;
+    llvm::llvm_shutdown();
   
-  return 0;
+    return 0;
 }
 

--- a/src/parser/Parser.cpp
+++ b/src/parser/Parser.cpp
@@ -16,11 +16,11 @@
 #include "../ast/expr/BreakExpr.h"
 #include "../ast/expr/IfExpr.h"
 
-static llvm::GlobalVariable *__Brain_IndexPtr = NULL;
-static llvm::GlobalVariable *__Brain_CellsPtr = NULL;
+static llvm::GlobalVariable *__Brain_IndexPtr = nullptr;
+static llvm::GlobalVariable *__Brain_CellsPtr = nullptr;
 static bool hasDoneThen = false;
 
-bool Parser::isSkippable(char c)
+bool Parser::is_skippable(char c)
 {
   return (c != '<' && c != '>' &&
           c != '+' && c != '-' &&
@@ -33,201 +33,168 @@ bool Parser::isSkippable(char c)
           c != ':' && c != ';');
 }
 
-char Parser::getToken()
+char Parser::get_token()
 {
   char c = 0;
-  while ( (c = _data[_index++]) && isSkippable(c) ) { }
+  while ( (c = _data[_index++]) && is_skippable(c) ) { }
   return c;
 }
 
-void Parser::parse(std::vector<Expr *> &exprs, int level)
+void Parser::parse(std::vector<Expression *> &exprs, int level)
 {
-   char c = 0;
-   while ( (c = getToken()) ) 
-   {
-     Expr *expr = NULL;
-     if (ArgsOptions::instance()->getOptimization() == BO_IS_OPTIMIZING_O1 && !exprs.empty())
-     {
-       Expr *lastExpr = exprs.back();
-       if (lastExpr->UpdateExpr(c))
-         continue;
-     }
+    char c = 0;
+    while ((c = get_token()))  {
+	Expression *expr = NULL;
+	if (ArgsOptions::instance()->get_optimization() == BO_IS_OPTIMIZING_O1 && !exprs.empty()) {
+	    Expression *lastExpr = exprs.back();
+	    if (lastExpr->update_expression(c)) {
+		continue;
+	    }
+	}
 
-     switch (c)
-     {
-       case '<':
-       {
-         expr = new ShiftExpr(-1); 
-         break;
-       }
-       case '>':
-       {
-         expr = new ShiftExpr(1); 
-         break;
-       }
-       case '+':
-       {
-         expr = new IncrementExpr(1);
-         break;
-       }
-       case '-':
-       {
-         expr = new IncrementExpr(-1);
-         break;
-       }
-       case '.':
-       {
-         expr = new OutputExpr();
-         break;
-       }
-       case ',':
-       {
-         expr = new InputExpr();
-         break;
-       }
-       case '[':
-       {
-         std::vector<Expr *> loopExpr;
-         parse(loopExpr, level + 1);
-         expr = new LoopExpr(loopExpr, LT_WHILE);
-         break;
-       }
-       case ']':
-       {
-         if (level > 0)
-           return; // exit the recursivity
-         break; 
-       }
-       case '{':
-       {
-         std::vector<Expr *> loopExpr;
-         parse(loopExpr, level + 1);
-         expr = new LoopExpr(loopExpr, LT_FOR);
-         break;
-       }
-       case '}':
-       {
-         if (level > 0)
-           return; // exit the recursivity
-         break;
-       }
-       case '?':
-       {
-         std::vector<Expr *> ifExpr;
-         parse(ifExpr, level + 1);
-         expr = new IfExpr(ifExpr);
-         break;
-       }
-       case ':':
-       {
-         if (!hasDoneThen)
-         {
-           if (level == 0)
-             break;
-
-           _index--; // move one step back to read the ':' again
-           hasDoneThen = true;
-           return; // return to exit the 'then' recursivity
-         }
-        
-         if (!exprs.empty()) // do the else
-         {
-           Expr *expr = exprs.back();
-           if (expr->ExprCategory() == ET_BRANCH)
-           {
-             std::vector<Expr *> elseExpr;
-             parse(elseExpr, level + 1);
-             ((IfExpr *)expr)->SetElse (elseExpr);
-           }
-         }
-
-         hasDoneThen = false; // reset the flag       
-
-         break;
-       }
-       case ';':
-       {
-         if (level > 0)
-           return;
-         break;
-       }
-       case '*':
-       {
-         expr = new ArithmeticExpr(AT_MUL);
-         break;
-       }
-       case '/':
-       {
-         expr = new ArithmeticExpr(AT_DIV);
-         break;
-       }
-       case '%':
-       {
-         expr = new ArithmeticExpr(AT_REM);
-         break;
-       }
-       case '#':
-       {
-         expr = new DebugExpr();
-         break;
-       }
-       case '!':
-       {
-         expr = new BreakExpr();
-         break;
-       }
-       default: 
-       {
-         break; // Ignored character
-       }
-     }
-
-     if (expr) 
-     {
-       exprs.push_back(expr);
-     }
-   }
+	switch (c)
+	{
+	case '<':
+	    expr = new ShiftExpression(-1); 
+	    break;
+	case '>':
+	    expr = new ShiftExpression(1); 
+	    break;
+	case '+':
+	    expr = new IncrementExpression(1);
+	    break;
+	case '-':
+	    expr = new IncrementExpression(-1);
+	    break;
+	case '.':
+	    expr = new OutputExpression();
+	    break;
+	case ',':
+	    expr = new InputExpression();
+	    break;
+	case '[':
+	{
+	    std::vector<Expression *> loopExpr;
+	    parse(loopExpr, level + 1);
+	    expr = new LoopExpression(loopExpr, LT_WHILE);
+	    break;
+	}
+	case ']':
+	    if (level > 0) {
+		return; // exit the recursivity
+	    }
+	    break; 
+	case '{':
+	{
+	    std::vector<Expression *> loopExpr;
+	    parse(loopExpr, level + 1);
+	    expr = new LoopExpression(loopExpr, LT_FOR);
+	    break;
+	}
+	case '}':
+	    if (level > 0) {
+		return; // exit the recursivity
+	    }
+	    break;
+	case '?':
+	{
+	    std::vector<Expression *> ifExpr;
+	    parse(ifExpr, level + 1);
+	    expr = new IfExpression(ifExpr);
+	    break;
+	}
+	case ':':
+	    if (!hasDoneThen) {
+		if (level == 0) {
+		    break;
+		}
+	    }
+	    
+	    _index--; // move one step back to read the ':' again
+	    hasDoneThen = true;
+	    return; // return to exit the 'then' recursivity
+	
+	    // do the else
+	    if (!exprs.empty()) {
+		Expression *expr = exprs.back();
+		if (expr->expression_category() == ET_BRANCH) {
+		    std::vector<Expression *> elseExpr;
+		    parse(elseExpr, level + 1);
+		    ((IfExpression *)expr)->set_else(elseExpr);
+		}
+	    }
+	
+	    hasDoneThen = false; // reset the flag
+	    break;
+	case ';':
+	    if (level > 0) {
+		return;
+	    }
+	    break;
+	case '*':
+	    expr = new ArithmeticExpression(AT_MUL);
+	    break;
+	case '/':
+	    expr = new ArithmeticExpression(AT_DIV);
+	    break;
+	case '%':
+	    expr = new ArithmeticExpression(AT_REM);
+	    break;
+	case '#':
+	    expr = new DebugExpression();
+	    break;
+	case '!':
+	    expr = new BreakExpression();
+	    break;
+	default:
+	    // Ignored character
+	    break;
+	}
+    
+	if (expr) {
+	    exprs.push_back(expr);
+	}
+    }
 }
 
-void Parser::CodeGen(llvm::Module *M, llvm::IRBuilder<> &B)
+void Parser::code_gen(llvm::Module *M, llvm::IRBuilder<> &B)
 {
-  llvm::LLVMContext &C = M->getContext();
+    llvm::LLVMContext &C = M->getContext();
   
-  if (!__Brain_IndexPtr)
-  {
-    // Create global variable |brainf.index|
-    llvm::Type *Ty = llvm::Type::getInt32Ty(C);
-    const llvm::APInt Zero = llvm::APInt(32, 0); // int32 0
-    llvm::Constant *InitV = llvm::Constant::getIntegerValue(Ty, Zero);
+    if (!__Brain_IndexPtr) {
+	// Create global variable |brainf.index|
+	llvm::Type *Ty = llvm::Type::getInt32Ty(C);
+	const llvm::APInt Zero = llvm::APInt(32, 0); // int32 0
+	llvm::Constant *InitV = llvm::Constant::getIntegerValue(Ty, Zero);
     __Brain_IndexPtr = new llvm::GlobalVariable(*M, Ty, false /* non-constant */,
                                            llvm::GlobalValue::WeakAnyLinkage, // Keep one copy when linking (weak)
                                            InitV, "brainf.index");
   }
   
-  if (!__Brain_CellsPtr)
-  {
-    #define kCellsCount 100
-    // Create |brainf.cells|
-    llvm::ArrayType *ArrTy = llvm::ArrayType::get(llvm::Type::getInt32Ty(C), kCellsCount);
-    std::vector<llvm::Constant *> constants(kCellsCount, B.getInt32(0)); // Create a vector of kCellsCount items equal to 0
-    llvm::ArrayRef<llvm::Constant *> Constants = llvm::ArrayRef<llvm::Constant *>(constants);
-    llvm::Constant *InitPtr = llvm::ConstantArray::get(ArrTy, Constants);
-    __Brain_CellsPtr = new llvm::GlobalVariable(*M, ArrTy, false /* non-constant */,
-                                           llvm::GlobalValue::WeakAnyLinkage, // Keep one copy when linking (weak)
+    if (!__Brain_CellsPtr) {
+#define kCellsCount 100
+	// Create |brainf.cells|
+	llvm::ArrayType *ArrTy = llvm::ArrayType::get(llvm::Type::getInt32Ty(C), kCellsCount);
+	std::vector<llvm::Constant *> constants(kCellsCount, B.getInt32(0)); // Create a vector of kCellsCount items equal to 0
+	llvm::ArrayRef<llvm::Constant *> Constants = llvm::ArrayRef<llvm::Constant *>(constants);
+	llvm::Constant *InitPtr = llvm::ConstantArray::get(ArrTy, Constants);
+	__Brain_CellsPtr = new llvm::GlobalVariable(*M, ArrTy, false /* non-constant */,
+						llvm::GlobalValue::WeakAnyLinkage,
+// Keep one copy when linking (weak)
                                            InitPtr, "brainf.cells");
   }
 
-  for (std::vector<Expr *>::iterator it = _exprs.begin(); it != _exprs.end(); ++it) 
-  {
-    (*it)->CodeGen(M, B, __Brain_IndexPtr, __Brain_CellsPtr);
-  }
+    for (std::vector<Expression *>::iterator it = _exprs.begin();
+	 it != _exprs.end(); ++it) {
+	(*it)->code_gen(M, B, __Brain_IndexPtr, __Brain_CellsPtr);
+    }
 }
 
-void Parser::DebugDescription(int level)
+void Parser::debug_description(int level)
 {
-  for (std::vector<Expr *>::iterator it = _exprs.begin(); it != _exprs.end(); ++it) 
-  {
-    std::cout << std::string(level * 2, ' ');
-    (*it)->DebugDescription(level+1);
-  }
+    for (std::vector<Expression *>::iterator it = _exprs.begin();
+	 it != _exprs.end(); ++it) {
+	std::cout << std::string(level * 2, ' ');
+	(*it)->debug_description(level+1);
+    }
 }

--- a/src/parser/Parser.h
+++ b/src/parser/Parser.h
@@ -11,26 +11,54 @@
 #include <string>
 #include <vector>
 
-#include "llvm/IR/IRBuilder.h"
-#include "llvm/IR/Module.h"
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/Module.h>
 
 #include "../ast/expr/Expr.h"
 #include "../utils/ArgsOptions.h"
 
+/**
+ * @brief
+ */
 class Parser
 {
-  protected:
+protected:
     std::string _data;
     int _index;
-    std::vector<Expr *> _exprs;
-  
-    static bool isSkippable(char c);
-    char getToken();
-    void parse(std::vector<Expr *> &exprs, int level);
-  public:
+    std::vector<Expression *> _exprs;
+
+    /**
+     * @brief
+     * @param c
+     */
+    static bool is_skippable(char c);
+    /**
+     * @brief
+     */
+    char get_token();
+    /**
+     * @brief
+     * @param exprs
+     * @param level
+     */
+    void parse(std::vector<Expression *> &exprs, int level);
+public:
+    /**
+     * @brief
+     * @param s
+     */
     Parser(std::string s) : _data(s), _index(0) { parse(_exprs, 0); }
-    void CodeGen(llvm::Module *M, llvm::IRBuilder<> &B);
-    void DebugDescription(int level);
+    /**
+     * @brief
+     * @param M
+     * @param B
+     */
+    void code_gen(llvm::Module *M, llvm::IRBuilder<> &B);
+    /**
+     * @brief
+     * @param level
+     */
+    void debug_description(int level);
 };
 
-#endif 
+#endif // PARSER_H 

--- a/src/utils/ArgsHandler.cpp
+++ b/src/utils/ArgsHandler.cpp
@@ -7,108 +7,99 @@
 
 #include <iostream>
 #include <fstream>
+#include <string>
 #include <streambuf>
 
 #include "ArgsHandler.h"
 
-#define BRAIN_VERSION 0.8
-#define BRAIN_FORMAT "Please execute Brain with the command: brain filename\n"
-#define BRAIN_HELP "Use the identifier '--help' for getting information about the settings\n";
-#define BRAIN_OPT_ERR "You can not use more than one type of optimization at time.\n"
+const std::string BRAIN_VERSION =  "0.8";
+const std::string BRAIN_FORMAT = "Please execute Brain with the command: brain filename\n";
+const std::string BRAIN_HELP = "Use the identifier '--help' for getting information about the settings\n";
+const std::string BRAIN_OPT_ERR = "You can not use more than one type of optimization at time.\n";
 
-void ArgsHandler::handle(int argc, char *argv[])
+void ArgsHandler::handle(int argc, char **argv)
 {
-  if (argc < 2)
-  {
-    std::cout << "Brain version " << BRAIN_VERSION << ". "
-              << BRAIN_FORMAT
-              << BRAIN_HELP;
-    exit(-1);
+    if (argc < 2) {
+	std::cout << "Brain version " << BRAIN_VERSION << ". "
+		  << BRAIN_FORMAT
+		  << BRAIN_HELP;
+	exit(-1);
+    }
+  
+    for (int i = 1; i < argc; i++) {
+	std::string str(argv[i]);
+    
+	if (str.compare("--help") == 0 || str.compare("-help") == 0) {
+	    std::cout << "\n"
+		      << "-emit-llvm\tEmits LLVM IR code for the given input\n"
+		      << "-emit-ast\tEmits the AST for the given input\n"
+		      << "-v\t\tUses verbose mode for the output\n"
+		      << "-O0\t\tGenerates output code with no optmizations\n"
+		      << "-O1\t\tOptimizes Brain generated output code (Default)\n" 
+		      << "\n";
+	    exit(0);
+	}
+	else if (str.compare("--version") == 0 ||
+		 str.compare("-version") == 0) {
+	    std::cout << "Brain version " << BRAIN_VERSION << ".\n"
+		      << BRAIN_HELP;
+	    exit(0);
+	}
+	else if (str.compare("-emit-llvm") == 0) {
+	    ArgsOptions::instance()->add_option(BO_IS_EMITTING_LLVM);
+	}
+	else if (str.compare("-emit-ast") == 0) {
+	    ArgsOptions::instance()->add_option(BO_IS_EMITTING_AST);
+	}
+	else if (str.compare("-v") == 0) {
+	    ArgsOptions::instance()->add_option(BO_IS_VERBOSE);
+	}
+	else if (str.compare("-O0") == 0) {
+	    if (ArgsOptions::instance()->has_option(BO_IS_OPTIMIZING_O1)) {
+		std::cout << BRAIN_OPT_ERR;
+		exit(-1);
+	    }
+
+	    ArgsOptions::instance()->add_option(BO_IS_OPTIMIZING_O0);
+	}
+	else if (str.compare("-O1") == 0)
+	{
+	    if (ArgsOptions::instance()->has_option(BO_IS_OPTIMIZING_O0)) {
+		std::cout << BRAIN_OPT_ERR;
+		exit(-1);
+	    }
+	    
+	    ArgsOptions::instance()->add_option(BO_IS_OPTIMIZING_O1);
+	}
+	else if ((str.size() > 2 && str.substr(str.size()-2,2) == ".b") ||
+		 (str.size() > 3 && str.substr(str.size()-3,3) == ".br") ||
+		 (str.size() > 6 && str.substr(str.size()-6,6) == ".brain")) {
+	    std::ifstream t(str);
+	    std::string str_file((std::istreambuf_iterator<char>(t)),
+				std::istreambuf_iterator<char>());
+	    if (str_file.empty()) {
+		std::cout << "No such file '" << str << "'\n"
+			  << BRAIN_FORMAT;
+		exit(-1);
+	    }
+	    _string_file = str_file;
+	}
+	else if (str.find("-") == 0)
+	{
+	    std::cout << "Unsupported option \"" << str << "\"\n"
+		      << BRAIN_HELP;
+	    exit(-1);
+	}
+	else
+	{
+	    std::cout << "No such file '" << str << "'\n"
+		      << BRAIN_FORMAT
+		      << BRAIN_HELP;
+	    exit(-1);
+	}
   }
 
-  for (int i = 1; i < argc; i++)
-  {
-    std::string str(argv[i]);
-    if (str.compare("--help") == 0 || str.compare("-help") == 0)
-    {
-      std::cout << "\n"
-                << "-emit-llvm\tEmits LLVM IR code for the given input\n"
-                << "-emit-ast\tEmits the AST for the given input\n"
-                << "-v\t\tUses verbose mode for the output\n"
-                << "-O0\t\tGenerates output code with no optmizations\n"
-                << "-O1\t\tOptimizes Brain generated output code (Default)\n" 
-                << "\n";
-      exit(0);
-    }
-    else if (str.compare("--version") == 0 || str.compare("-version") == 0)
-    {
-      std::cout << "Brain version " << BRAIN_VERSION << ".\n"
-              << BRAIN_HELP;
-      exit(0);
-    }
-    else if (str.compare("-emit-llvm") == 0)
-    {
-      ArgsOptions::instance()->addOption(BO_IS_EMITTING_LLVM);
-    }
-    else if (str.compare("-emit-ast") == 0)
-    {
-      ArgsOptions::instance()->addOption(BO_IS_EMITTING_AST);
-    }
-    else if (str.compare("-v") == 0)
-    {
-      ArgsOptions::instance()->addOption(BO_IS_VERBOSE);
-    }
-    else if (str.compare("-O0") == 0)
-    {
-      if (ArgsOptions::instance()->hasOption(BO_IS_OPTIMIZING_O1))
-      {
-        std::cout << BRAIN_OPT_ERR;
-        exit(-1);
-      }
-
-      ArgsOptions::instance()->addOption(BO_IS_OPTIMIZING_O0);
-    }
-    else if (str.compare("-O1") == 0)
-    {
-      if (ArgsOptions::instance()->hasOption(BO_IS_OPTIMIZING_O0))
-      {
-        std::cout << BRAIN_OPT_ERR;
-        exit(-1);
-      }
-
-      ArgsOptions::instance()->addOption(BO_IS_OPTIMIZING_O1);
-    }
-    else if ((str.size() > 2 && str.substr(str.size()-2,2) == ".b")    || 
-             (str.size() > 3 && str.substr(str.size()-3,3) == ".br")   ||
-             (str.size() > 6 && str.substr(str.size()-6,6) == ".brain" ))
-    {
-      std::ifstream t(str);
-      std::string strFile((std::istreambuf_iterator<char>(t)),
-                       std::istreambuf_iterator<char>());
-     if (strFile.empty())
-     {
-       std::cout << "No such file '" << str << "'\n"
-                 << BRAIN_FORMAT;
-       exit(-1);
-     }
-      _stringFile = strFile;
-    }
-    else if (str.find("-") == 0)
-    {
-      std::cout << "Unsupported option '" << str << "'\n"
-                << BRAIN_HELP;
-       exit(-1);
-    }
-    else
-    {
-      std::cout << "No such file '" << str << "'\n"
-                << BRAIN_FORMAT
-                << BRAIN_HELP;
-       exit(-1);
-    }
-  }
-
-  if (_stringFile.empty())
+  if (_string_file.empty())
   {
     std::cout << "No input files\n"
               << BRAIN_FORMAT;
@@ -116,8 +107,8 @@ void ArgsHandler::handle(int argc, char *argv[])
   }
 }
 
-std::string ArgsHandler::getStringFile()
+std::string ArgsHandler::get_string_file()
 {
-  return _stringFile;
+  return _string_file;
 }
 

--- a/src/utils/ArgsHandler.h
+++ b/src/utils/ArgsHandler.h
@@ -12,14 +12,23 @@
 
 #include "ArgsOptions.h"
 
+/**
+ * @brief Consumes the arguments passed to brain and do whatever actions it's supposed to.
+ */
 class ArgsHandler 
 {
-  protected:
-    std::string _stringFile;
+protected:
+    std::string _string_file;
+    /**
+     * @brief
+     */
     void handle(int argc, char *argv[]);
-  public:
+public:
     ArgsHandler(int argc, char *argv[]) { handle(argc, argv); }
-    std::string getStringFile();
+    /**
+     * @brief
+     */
+    std::string get_string_file();
 };
 
-#endif
+#endif // ARGS_HANDLER_H

--- a/src/utils/ArgsOptions.cpp
+++ b/src/utils/ArgsOptions.cpp
@@ -11,35 +11,34 @@ ArgsOptions *ArgsOptions::_instance = nullptr;
 
 ArgsOptions* ArgsOptions::instance()
 {
-  if (!ArgsOptions::_instance)
-    ArgsOptions::_instance = new ArgsOptions();
-  return _instance;
+    if (!ArgsOptions::_instance) {
+	ArgsOptions::_instance = new ArgsOptions();
+    }
+  
+    return _instance;
 }
 
-void ArgsOptions::addOption(BrainOption option)
+void ArgsOptions::add_option(BrainOption option)
 {
-  _options |= option;
+    _options |= option;
 }
 
-bool ArgsOptions::hasOption(BrainOption option)
+bool ArgsOptions::has_option(BrainOption option)
 {
-  return (_options & option) == option;
+    return (_options & option) == option;
 }
 
-BrainOption ArgsOptions::getOptimization()
+BrainOption ArgsOptions::get_optimization()
 {
-  // default value
-  if ((_options & BO_IS_OPTIMIZING_O1) == 0 &&
-     (_options & BO_IS_OPTIMIZING_O0) == 0)
-  {
-    return BO_IS_OPTIMIZING_O1;
-  }
-  else if ((_options & BO_IS_OPTIMIZING_O1) == BO_IS_OPTIMIZING_O1)
-  {
-    return BO_IS_OPTIMIZING_O1;
-  }
-  else
-  {
-    return BO_IS_OPTIMIZING_O0;
-  }
+    // default value
+    if ((_options & BO_IS_OPTIMIZING_O1) == 0 &&
+	(_options & BO_IS_OPTIMIZING_O0) == 0) {
+	return BO_IS_OPTIMIZING_O1;
+    }
+    else if ((_options & BO_IS_OPTIMIZING_O1) == BO_IS_OPTIMIZING_O1) {
+	return BO_IS_OPTIMIZING_O1;
+    }
+    else {
+	return BO_IS_OPTIMIZING_O0;
+    }
 }

--- a/src/utils/ArgsOptions.h
+++ b/src/utils/ArgsOptions.h
@@ -16,21 +16,39 @@ typedef enum
   BO_IS_VERBOSE = 4,
   BO_IS_OPTIMIZING_O0 = 8,
   BO_IS_OPTIMIZING_O1 = 16
-}BrainOption;
+} BrainOption;
 
+/**
+ * @brief Handles all the inputs to Brain.
+ *
+ */
 class ArgsOptions
 {
-  private:
+private:
     ArgsOptions() : _options(BO_NONE) {}
     static ArgsOptions *_instance;
     int _options;
-  public:
+public:
     ArgsOptions(ArgsOptions const&) = delete;
     ArgsOptions& operator=(ArgsOptions const&) = delete;
+    /**
+     * @brief Returns the AST instance.
+     */
     static ArgsOptions* instance();
-    void addOption(BrainOption option);
-    bool hasOption(BrainOption option);
-    BrainOption getOptimization();
+    /**
+     * @brief
+     * @param option
+     */
+    void add_option(BrainOption option);
+    /**
+     * @brief
+     * @param option
+     */
+    bool has_option(BrainOption option);
+    /**
+     * @brief
+     */
+    BrainOption get_optimization();
 };
 
-#endif
+#endif // ARGS_OPTIONS_H


### PR DESCRIPTION
This is a huge commit and its main purpose was to align the source code
to Stroustrup guidelines, though I don't know if it's fully compliant to
it.
    
Removed somme inner blocks of scope in some switch statements and
changed the way LLVM files are included in the project, instead of the
quote symbol I'm adopting the angle brackets because the LLVM are found
in the path and not in the project tree.
    
Also were added documentation entries with some information in it to
documentation be later generated. But there is a lot to do, a real deep
look at the code is needed to improve it.

Signed-off-by: Rafael Campos Nunes <rafaelnunes@engineer.com>